### PR TITLE
Remove xenial series from charm.

### DIFF
--- a/charm/zookeeper/metadata.yaml
+++ b/charm/zookeeper/metadata.yaml
@@ -11,7 +11,6 @@ tags:
 - distributed
 subordinate: false
 series:
-- xenial
 - bionic
 provides:
   zookeeper:


### PR DESCRIPTION
xenial could be supported, but we'll standardize on bionic unless there
is some reason to deploy onto xenial.