### PR TITLE
Remove zk_watch_count from nagios checks.

### DIFF
--- a/charm/zookeeper/reactive/nagios.py
+++ b/charm/zookeeper/reactive/nagios.py
@@ -49,11 +49,6 @@ def setup_nagios(nagios):
         'description': 'ZK_Outstanding_Requests',
         'warn': 20,
         'crit': 50,
-    }, {
-        'name': 'zk_watch_count',
-        'description': 'ZK_Watch_Count',
-        'warn': 100,
-        'crit': 500,
     }]
     check_cmd = ['/usr/local/lib/nagios/plugins/check_zookeeper.py',
                  '-o', 'nagios',


### PR DESCRIPTION
It's not a very useful check in a Kafka cluster. It's basically a
function of the number of topics * partitions. Memory utilization is a
better indication of a resource problem.