### PR TITLE
Set up a state directory and file for check_zookeeper script.

### DIFF
--- a/charm/zookeeper/files/check_zookeeper.py
+++ b/charm/zookeeper/files/check_zookeeper.py
@@ -30,7 +30,6 @@ import sys
 import socket
 import logging
 import subprocess
-import os
 
 from datetime import datetime
 from io import StringIO
@@ -171,13 +170,11 @@ class GangliaHandler(object):
 
 class ZooKeeperServer(object):
     def __init__(self, host='localhost', port='2181', timeout=1,
-                 meta_file='/tmp/zk_check/meta'):
+                 meta_file='/var/lib/check_zookeeper/meta'):
         self._address = (host, int(port))
         self._timeout = timeout
         self._last_reset = datetime.utcnow()
         self._meta_path = meta_file
-
-        os.makedirs(os.path.dirname(meta_file), exist_ok=True)
 
         with open(meta_file, 'a+') as f:
             f.seek(0)

--- a/charm/zookeeper/reactive/nagios.py
+++ b/charm/zookeeper/reactive/nagios.py
@@ -83,4 +83,15 @@ def install_nrpe_helper():
     dst = '{}/check_zookeeper.py'.format(dst_dir)
     shutil.copy(src, dst)
     os.chmod(dst, 0o755)
+
+    # Create directory for check script state file, repair permissions and
+    # ownership
+    state_dir = '/var/lib/check_zookeeper'
+    os.makedirs(state_dir, mode=0o755, exist_ok=True)
+    shutil.chown(state_dir, 'nagios', 'nagios')
+    meta_file = os.path.join(state_dir, 'meta')
+    if os.path.exists(meta_file):
+        os.chmod(meta_file, 0o644)
+        shutil.chown(meta_file, 'nagios', 'nagios')
+
     set_state('zookeeper.nrpe_helper.installed')


### PR DESCRIPTION
The charm will create a directory for storing the nagios check state,
rather than relying on /tmp, which seems to be unreliable.