### PR TITLE
Use .total_seconds() instead of .seconds to expire stats.

### DIFF
--- a/charm/zookeeper/files/check_zookeeper.py
+++ b/charm/zookeeper/files/check_zookeeper.py
@@ -193,7 +193,7 @@ class ZooKeeperServer(object):
         """ Get ZooKeeper server stats as a map """
         # Reset stats every hour
         td = datetime.utcnow() - self._last_reset
-        if td.seconds // 60 >= STATS_RESET_INTERVAL_MINUTES:
+        if td.total_seconds() // 60 >= STATS_RESET_INTERVAL_MINUTES:
             self._reset_stats()
 
         data = self._send_cmd('mntr')


### PR DESCRIPTION
The 'seconds' property on datetime.timedelta does not reflect the actual
number of seconds of the timedelta, should use total_seconds() for this.